### PR TITLE
ci: add dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,12 @@
+name: Dependabot Auto-Merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    uses: brickhouse-tech/.github/.github/workflows/dependabot-auto-merge.yml@main
+


### PR DESCRIPTION
Adds the standard dependabot auto-merge workflow that calls the reusable workflow from the `.github` org repo. Dependabot PRs will be auto-approved and merged.