### PR TITLE
security: harden publish workflow against Mini Shai-Hulud (pin + egress)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,15 +13,29 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            uploads.github.com:443
+            registry.npmjs.org:443
+            nodejs.org:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Build and Publish
         run: |
           npm install -g npm@11
-          npm ci
+          npm ci --ignore-scripts
           npm run build
           npm publish --access public --provenance

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,6 @@
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [2, 'always', ['feat','fix','docs','style','refactor','perf','test','build','ci','chore','revert','security']],
+  },
+};


### PR DESCRIPTION
## Summary

Part of the **Mini Shai-Hulud supply chain hardening campaign** — closing OIDC hijack vectors in GitHub Actions publish pipelines across the brickhouse-tech org and related repos.

### Changes

- Pin `actions/checkout` to SHA `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
- Pin `actions/setup-node` to SHA `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (v6.4.0)
- Add `step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450` (v2.19.1) as first step with egress block allowlist
- Add `--ignore-scripts` to `npm ci` to block postinstall/preinstall script execution
- Permissions `id-token: write` + `contents: read` were already present — left intact

### Threat model

TeamPCP's Mini Shai-Hulud worm uses OIDC identity injection to hijack publish pipelines mid-workflow. Unpinned action refs allow SHA-swapping attacks; permissive egress allows exfiltration; missing `--ignore-scripts` allows dependency install-time code execution.

### Precedent

Same pattern already merged in:
- brickhouse-tech/.github#7
- brickhouse-tech/node-xml2js#6
- brickhouse-tech/angular.js#10
- brickhouse-tech/json-schema#4

## Test plan

- [ ] Workflow YAML is valid (no syntax errors)
- [ ] SHA pins match the tagged releases (v4.2.2, v6.4.0, harden-runner v2.19.1)
- [ ] `npm ci --ignore-scripts` + `npm run build` does not break the publish for this package
- [ ] harden-runner egress allowlist covers all required endpoints for npm publish + OIDC