### PR TITLE
ci: forward secrets to reusable dependabot auto-merge (release cascade)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,4 +9,5 @@ permissions:
 jobs:
   dependabot:
     uses: brickhouse-tech/.github/.github/workflows/dependabot-auto-merge.yml@main
+    secrets: inherit
 


### PR DESCRIPTION
Adds `secrets: inherit` so the shared reusable auto-merge workflow enables auto-merge with the GH_TOKEN PAT, restoring the release cascade that GITHUB_TOKEN merges silently broke. Requires GH_TOKEN to exist as a Dependabot secret in this repo. See brickhouse-tech/.github reusable dependabot-auto-merge.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)